### PR TITLE
List `repository` in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 description = 'A space optimized version of `Vec<Option<T>>` that stores the discriminant seperately'
 license = 'MIT'
 readme = 'README.md'
+repository = "https://github.com/RustyYato/vec-option"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Thanks for making this crate! I'm surprised it's not more popular.

This PR simply adds a [`repository` field](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) to `Cargo.toml` so that it's easier to find this repo from the [crate page](https://crates.io/crates/vec-option).